### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix divide by zero and insecure randomness in CDarkSendRelay::Relay

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-17 - Insecure Randomness and Divide by Zero in Peer Selection
+**Vulnerability:** `CDarkSendRelay::Relay()` used the insecure `rand()` function combined with `rand() % nCount` without checking if `nCount` was 0, leading to a potential divide-by-zero vulnerability. Additionally, if `nCount == 1`, an infinite loop would occur because it required two unique peers.
+**Learning:** Hardcoded uses of `rand()` in C++ projects for critical things like node selection can lead to non-uniform distribution and predictable patterns. It can also easily introduce math-related crashes (modulo by zero) and infinite loops in peer negotiation logic.
+**Prevention:** Always use secure randomness like `GetRandInt()` instead of `rand()`, and ensure proper boundary checks are present for modulo operations or loop invariants dependent on counts.

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -1,5 +1,6 @@
 #include "darksend.h"
 #include "darksend-relay.h"
+#include "random.h"
 
 
 CDarkSendRelay::CDarkSendRelay()
@@ -84,17 +85,21 @@ bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
 void CDarkSendRelay::Relay()
 {
     int nCount = std::min(mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION), 20);
-    int nRank1 = (rand() % nCount)+1; 
-    int nRank2 = (rand() % nCount)+1; 
 
-    //keep picking another second number till we get one that doesn't match
-    while(nRank1 == nRank2) nRank2 = (rand() % nCount)+1;
+    if (nCount == 0) return;
 
-    //printf("rank 1 - rank2 %d %d \n", nRank1, nRank2);
-
-    //relay this message through 2 separate nodes for redundancy
+    int nRank1 = GetRandInt(nCount) + 1;
     RelayThroughNode(nRank1);
-    RelayThroughNode(nRank2);
+
+    if (nCount > 1) {
+        int nRank2 = GetRandInt(nCount) + 1;
+
+        //keep picking another second number till we get one that doesn't match
+        while(nRank1 == nRank2) nRank2 = GetRandInt(nCount) + 1;
+
+        //relay this message through 2 separate nodes for redundancy
+        RelayThroughNode(nRank2);
+    }
 }
 
 void CDarkSendRelay::RelayThroughNode(int nRank)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `CDarkSendRelay::Relay()` used the insecure `rand()` function for peer selection and had a divide-by-zero vulnerability if the peer count was 0 (`rand() % nCount`). It also had an infinite loop vulnerability if the peer count was exactly 1.
🎯 Impact: An attacker or network conditions could trigger a crash (modulo by zero) or a denial-of-service hang (infinite loop), and insecure peer selection could lead to eclipse attacks.
🔧 Fix: Replaced `rand()` with `GetRandInt()` for secure randomness. Added checks to return early if peer count is 0 and to skip the second peer selection loop if the peer count is exactly 1.
✅ Verification: The codebase compiles successfully and the edge cases are properly guarded.

---
*PR created automatically by Jules for task [4827498664867389803](https://jules.google.com/task/4827498664867389803) started by @DerUntote*