### PR TITLE
🔒 Fix Unsafe String Formatting (sprintf) in GetHex

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** `CDarkSendRelay::Relay()` used the insecure `rand()` function combined with `rand() % nCount` without checking if `nCount` was 0, leading to a potential divide-by-zero vulnerability. Additionally, if `nCount == 1`, an infinite loop would occur because it required two unique peers.
 **Learning:** Hardcoded uses of `rand()` in C++ projects for critical things like node selection can lead to non-uniform distribution and predictable patterns. It can also easily introduce math-related crashes (modulo by zero) and infinite loops in peer negotiation logic.
 **Prevention:** Always use secure randomness like `GetRandInt()` instead of `rand()`, and ensure proper boundary checks are present for modulo operations or loop invariants dependent on counts.
+
+## 2024-05-18 - Unsafe String Formatting in GetHex
+**Vulnerability:** `base_blob::GetHex` used `sprintf` to format hexadecimal characters into a fixed-size character array (`psz`).
+**Learning:** Using `sprintf` is inherently unsafe as it does not check the bounds of the destination buffer, creating a potential buffer overflow vulnerability if data sizes change or logic errors are introduced.
+**Prevention:** Always use bounds-checking formatting functions like `snprintf` instead of `sprintf` to ensure the bounds of arrays are respected.

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -22,7 +22,8 @@ std::string base_blob<BITS>::GetHex() const
 {
     char psz[sizeof(data) * 2 + 1];
     for (unsigned int i = 0; i < sizeof(data); i++)
-        sprintf(psz + i * 2, "%02x", data[sizeof(data) - i - 1]);
+        // Security Fix: Use snprintf to prevent potential buffer overflows
+        snprintf(psz + i * 2, 3, "%02x", data[sizeof(data) - i - 1]);
     return std::string(psz, psz + sizeof(data) * 2);
 }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Replaced an unsafe `sprintf` call with a safe `snprintf` call in the `GetHex` method of `src/uint256.cpp`.

⚠️ **Risk:** The potential impact if left unfixed
`sprintf` does not check the bounds of the destination buffer, which can lead to a potential buffer overflow vulnerability.

🛡️ **Solution:** How the fix addresses the vulnerability
The replacement uses `snprintf(psz + i * 2, 3, "%02x", data[sizeof(data) - i - 1]);` ensuring that exactly 2 characters and a null terminator are written on each iteration, preventing buffer overflows while maintaining the correct formatting of hexadecimal string representation.

---
*PR created automatically by Jules for task [3389014657083176595](https://jules.google.com/task/3389014657083176595) started by @DerUntote*