### PR TITLE
⚡ Bolt: Avoid unnecessary string copies in managers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Passing objects by const reference
+**Learning:** Found several manager components taking `std::string` and `CAddress` by value. This causes an unnecessary string allocation and copy for every invocation, impacting memory and CPU cache locally.
+**Action:** Always prefer `const T&` over pass-by-value for non-primitive types like `std::string` and container objects across codebase managers to reduce overhead.

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -8,23 +8,27 @@
 
 CNetFulfilledRequestManager netfulfilledman;
 
-void CNetFulfilledRequestManager::AddFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::AddFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
-bool CNetFulfilledRequestManager::HasFulfilledRequest(CAddress addr, std::string strRequest)
+bool CNetFulfilledRequestManager::HasFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
 
-    return  it != mapFulfilledRequests.end() &&
-            it->second.find(strRequest) != it->second.end() &&
-            it->second[strRequest] > GetTime();
+    if (it != mapFulfilledRequests.end()) {
+        fulfilledreqmapentry_t::iterator it_entry = it->second.find(strRequest);
+        if (it_entry != it->second.end()) {
+            return it_entry->second > GetTime();
+        }
+    }
+    return false;
 }
 
-void CNetFulfilledRequestManager::RemoveFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -36,9 +36,9 @@ public:
         READWRITE(mapFulfilledRequests);
     }
 
-    void AddFulfilledRequest(CAddress addr, std::string strRequest); // expire after 1 hour by default
-    bool HasFulfilledRequest(CAddress addr, std::string strRequest);
-    void RemoveFulfilledRequest(CAddress addr, std::string strRequest);
+    void AddFulfilledRequest(const CAddress& addr, const std::string& strRequest); // expire after 1 hour by default
+    bool HasFulfilledRequest(const CAddress& addr, const std::string& strRequest);
+    void RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest);
 
     void CheckAndRemove();
     void Clear();

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -166,7 +166,7 @@ int64_t CSporkManager::GetSporkValue(int nSporkID)
 
 }
 
-int CSporkManager::GetSporkIDByName(std::string strName)
+int CSporkManager::GetSporkIDByName(const std::string& strName)
 {
     if (strName == "SPORK_2_INSTANTSEND_ENABLED")               return SPORK_2_INSTANTSEND_ENABLED;
     if (strName == "SPORK_3_INSTANTSEND_BLOCK_FILTERING")       return SPORK_3_INSTANTSEND_BLOCK_FILTERING;
@@ -200,7 +200,7 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
     }
 }
 
-bool CSporkManager::SetPrivKey(std::string strPrivKey)
+bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
 {
     CSporkMessage spork;
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -111,10 +111,10 @@ public:
 
     bool IsSporkActive(int nSporkID);
     int64_t GetSporkValue(int nSporkID);
-    int GetSporkIDByName(std::string strName);
+    int GetSporkIDByName(const std::string& strName);
     std::string GetSporkNameByID(int nSporkID);
 
-    bool SetPrivKey(std::string strPrivKey);
+    bool SetPrivKey(const std::string& strPrivKey);
 };
 
 extern CSporkManager sporkManager;

--- a/src/vnodeconfig.cpp
+++ b/src/vnodeconfig.cpp
@@ -9,7 +9,7 @@
 
 CVnodeConfig vnodeConfig;
 
-void CVnodeConfig::add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex) {
+void CVnodeConfig::add(const std::string& alias, const std::string& ip, const std::string& privKey, const std::string& txHash, const std::string& outputIndex) {
     CVnodeEntry cme(alias, ip, privKey, txHash, outputIndex);
     entries.push_back(cme);
 }

--- a/src/vnodeconfig.h
+++ b/src/vnodeconfig.h
@@ -24,7 +24,7 @@ public:
         std::string outputIndex;
     public:
 
-        CVnodeEntry(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex) {
+        CVnodeEntry(const std::string& alias, const std::string& ip, const std::string& privKey, const std::string& txHash, const std::string& outputIndex) {
             this->alias = alias;
             this->ip = ip;
             this->privKey = privKey;
@@ -79,7 +79,7 @@ public:
 
     void clear();
     bool read(std::string& strErr);
-    void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+    void add(const std::string& alias, const std::string& ip, const std::string& privKey, const std::string& txHash, const std::string& outputIndex);
 
     std::vector<CVnodeEntry>& getEntries() {
         return entries;


### PR DESCRIPTION
💡 What: Replaced pass-by-value with pass-by-reference for `std::string` and `CAddress` in various manager classes (`CNetFulfilledRequestManager`, `CVnodeConfig`, `CSporkManager`). Also optimized `HasFulfilledRequest` to perform one map lookup instead of two.
🎯 Why: Passing non-primitive objects like `std::string` or `CAddress` by value causes unnecessary memory allocations and copies. Using a `const` reference is computationally cheaper while preserving the original intent. The double map lookup in `HasFulfilledRequest` further hurt performance as it essentially parsed the data structure twice.
📊 Impact: Decreases CPU cache misses and heap allocations per call of functions spanning multiple managers, particularly network-facing code like `HasFulfilledRequest`. Reduces complexity in `HasFulfilledRequest` from two O(log N) lookups down to just one. 
🔬 Measurement: Verified the logical change through source analysis; since this relies solely on C++ core rules (`const T&` binding to both rvalues and lvalues seamlessly), it will directly eliminate the `std::string` copy constructors in resulting compiled code. Added critical learning note to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [18419051817572392845](https://jules.google.com/task/18419051817572392845) started by @DerUntote*