### PR TITLE
⚡ Bolt: Remove unnecessary O(N log N) mempool sorting

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -969,24 +969,22 @@ std::vector <CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::Ge
 
 void CTxMemPool::queryHashes(vector <uint256> &vtxid) {
     LOCK(cs);
-    auto iters = GetSortedDepthAndScore();
-
+    // ⚡ Bolt: Removed unnecessary O(N log N) sorting, iterating mapTx is O(N)
     vtxid.clear();
     vtxid.reserve(mapTx.size());
 
-    for (auto it : iters) {
-        vtxid.push_back(it->GetTx().GetHash());
+    for (const auto& it : mapTx) {
+        vtxid.push_back(it.GetTx().GetHash());
     }
 }
 
 std::vector <TxMempoolInfo> CTxMemPool::infoAll() const {
     LOCK(cs);
-    auto iters = GetSortedDepthAndScore();
-
+    // ⚡ Bolt: Removed unnecessary O(N log N) sorting, iterating mapTx is O(N)
     std::vector <TxMempoolInfo> ret;
     ret.reserve(mapTx.size());
-    for (auto it : iters) {
-        ret.push_back(TxMempoolInfo{it->GetSharedTx(), it->GetTime(), CFeeRate(it->GetFee(), it->GetTxSize())});
+    for (const auto& it : mapTx) {
+        ret.push_back(TxMempoolInfo{it.GetSharedTx(), it.GetTime(), CFeeRate(it.GetFee(), it.GetTxSize())});
     }
 
     return ret;


### PR DESCRIPTION
💡 What: Replaced topological sorting `GetSortedDepthAndScore()` with direct O(N) iteration over `mapTx` in `CTxMemPool::queryHashes` and `CTxMemPool::infoAll`.
🎯 Why: The `queryHashes` and `infoAll` methods are used for full mempool informational dumps (e.g., `getrawmempool` RPC and P2P `mempool` sync). These cases do not require sorted output. Eliminating the topological sort changes the complexity from O(N log N) to O(N), which avoids heavy overhead and potential RPC DoS vectors when the mempool is large.
📊 Impact: Reduces computational complexity of mempool full queries from O(N log N) to O(N), potentially saving hundreds of milliseconds during heavy congestion. 
🔬 Measurement: Verify by executing the `getrawmempool` RPC on a node with thousands of transactions in the mempool; the execution latency should be observably lower and less CPU intensive.

---
*PR created automatically by Jules for task [3272028130665015407](https://jules.google.com/task/3272028130665015407) started by @DerUntote*