### PR TITLE
⚡ Bolt: Prevent deep copies in GetFullVnodeVector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-28 - Return large collections by const reference
+**Learning:** Returning large collections (like `std::vector<CVnode>`) by value from getter functions (e.g., `GetFullVnodeVector()`) causes expensive deep copies, becoming a significant performance bottleneck.
+**Action:** Always return large collections by `const reference` (e.g., `const std::vector<T>&`) in getters and ensure iteration loops use `const reference` (`BOOST_FOREACH(const T&, vec)`) to prevent unnecessary copying and avoid deep copies.

--- a/src/qt/vnodelist.cpp
+++ b/src/qt/vnodelist.cpp
@@ -274,10 +274,10 @@ void VnodeList::updateNodeList()
     ui->tableWidgetVnodes->clearContents();
     ui->tableWidgetVnodes->setRowCount(0);
 //    std::map<COutPoint, CVnode> mapVnodes = mnodeman.GetFullVnodeMap();
-    std::vector<CVnode> vVnodes = mnodeman.GetFullVnodeVector();
+    const std::vector<CVnode>& vVnodes = mnodeman.GetFullVnodeVector();
     int offsetFromUtc = GetOffsetFromUtc();
 
-    BOOST_FOREACH(CVnode & mn, vVnodes)
+    BOOST_FOREACH(const CVnode & mn, vVnodes)
     {
 //        CVnode mn = mnpair.second;
         // populate list

--- a/src/rpc/rpcvnode.cpp
+++ b/src/rpc/rpcvnode.cpp
@@ -488,8 +488,8 @@ UniValue vnodelist(const UniValue &params, bool fHelp) {
             obj.push_back(Pair(strOutpoint, s.first));
         }
     } else {
-        std::vector <CVnode> vVnodes = mnodeman.GetFullVnodeVector();
-        BOOST_FOREACH(CVnode & mn, vVnodes)
+        const std::vector<CVnode>& vVnodes = mnodeman.GetFullVnodeVector();
+        BOOST_FOREACH(const CVnode& mn, vVnodes)
         {
             std::string strOutpoint = mn.vin.prevout.ToStringShort();
             if (strMode == "activeseconds") {

--- a/src/vnode.h
+++ b/src/vnode.h
@@ -296,8 +296,8 @@ public:
 
     int GetCollateralAge();
 
-    int GetLastPaidTime() { return nTimeLastPaid; }
-    int GetLastPaidBlock() { return nBlockLastPaid; }
+    int GetLastPaidTime() const { return nTimeLastPaid; }
+    int GetLastPaidBlock() const { return nBlockLastPaid; }
     void UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack);
 
     // KEEP TRACK OF EACH GOVERNANCE ITEM INCASE THIS NODE GOES OFFLINE, SO WE CAN RECALC THEIR STATUS

--- a/src/vnodeman.cpp
+++ b/src/vnodeman.cpp
@@ -534,7 +534,7 @@ bool CVnodeMan::Has(const CTxIn& vin)
     return (pMN != NULL);
 }
 
-std::string CVnodeMan::GetNotQualifyReason(CVnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount)
+std::string CVnodeMan::GetNotQualifyReason(const CVnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount)
 {
     if (!mn.IsValidForPayment()) {
         return "false: 'not valid for payment'";

--- a/src/vnodeman.h
+++ b/src/vnodeman.h
@@ -284,7 +284,7 @@ public:
 
     vnode_info_t GetVnodeInfo(const CPubKey& pubKeyVnode);
 
-    std::string GetNotQualifyReason(CVnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount);
+    std::string GetNotQualifyReason(const CVnode& mn, int nBlockHeight, bool fFilterSigTime, int nMnCount);
 
     /// Find an entry in the vnode list that is next to be paid
     CVnode* GetNextVnodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
@@ -294,7 +294,8 @@ public:
     /// Find a random entry
     CVnode* FindRandomNotInVec(const std::vector<CTxIn> &vecToExclude, int nProtocolVersion = -1);
 
-    std::vector<CVnode> GetFullVnodeVector() { return vVnodes; }
+    // BOLT: Return by const reference to avoid deep copies of the vnode vector
+    const std::vector<CVnode>& GetFullVnodeVector() const { return vVnodes; }
 
     std::vector<std::pair<int, CVnode> > GetVnodeRanks(int nBlockHeight = -1, int nMinProtocol=0);
     int GetVnodeRank(const CTxIn &vin, int nBlockHeight, int nMinProtocol=0, bool fOnlyActive=true);


### PR DESCRIPTION
💡 What: Changed `GetFullVnodeVector` to return a `const std::vector<CVnode>&` instead of a deep copy, updated usages in UI and RPC code to use const references, and propagated constness to `CVnode` methods.
🎯 Why: Returning large collections by value is a recurring performance bottleneck in C++, causing expensive deep copies.
📊 Impact: Eliminates a full deep copy of the Vnodes list (which can contain thousands of items) on every table update or `vnodelist` RPC call, reducing CPU cycles and memory allocations significantly.
🔬 Measurement: Can be verified by running the `vnodelist full` RPC command on a network with a large number of nodes; memory usage should spike less and the response time will be incrementally faster.

---
*PR created automatically by Jules for task [18069873595965877828](https://jules.google.com/task/18069873595965877828) started by @DerUntote*