### PR TITLE
⚡ Bolt: optimize vector copies in GetVoteHashes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,8 @@
+
+## 2024-05-19 - Expensive Copies in Getters
+**Learning:** Returning large vectors by value in C++ leads to expensive deep copies and unnecessary performance overhead. This was observed in `GetFullVnodeVector` which returns a `std::vector<CVnode>`.
+**Action:** When working with getters for large vectors or collections in C++, ensure they return by `const reference` (e.g., `const std::vector<T>&`) to avoid expensive deep copies. Update call sites to use `const auto&` or `const std::vector<T>&` as well.
+
+## 2024-05-19 - Thread Safety Trumps Micro-Optimizations
+**Learning:** Returning a large mutable collection (e.g., `std::vector`) by reference from a global state manager (like `mnodeman` in a cryptocurrency node) is highly unsafe in a multithreaded environment. The original code intentionally returned a copy (a snapshot) to allow separate UI/RPC threads to iterate safely without locks. Changing this to return a reference introduces severe race conditions: if a network thread adds an item, the vector may reallocate its underlying memory, invalidating iterators and causing Segmentation Faults.
+**Action:** Before optimizing away deep copies (e.g., by changing return by value to return by reference), always verify the concurrency model. In architectures where the data is globally mutable by background threads, returning a snapshot (copy) is a necessary safety mechanism unless a robust, long-lived locking strategy is implemented. Revert optimizations that compromise thread safety.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5702,8 +5702,8 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                     LOCK(cs_mapVnodeBlocks);
                     if (mi != mapBlockIndex.end() && mnpayments.mapVnodeBlocks.count(mi->second->nHeight)) {
                         BOOST_FOREACH(CVnodePayee& payee, mnpayments.mapVnodeBlocks[mi->second->nHeight].vecPayees) {
-                            std::vector<uint256> vecVoteHashes = payee.GetVoteHashes();
-                            BOOST_FOREACH(uint256& hash, vecVoteHashes) {
+                            const std::vector<uint256>& vecVoteHashes = payee.GetVoteHashes();
+                            BOOST_FOREACH(const uint256& hash, vecVoteHashes) {
                                 if(mnpayments.HasVerifiedPaymentVote(hash)) {
                                     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                                     ss.reserve(1000);

--- a/src/vnode-payments.cpp
+++ b/src/vnode-payments.cpp
@@ -741,8 +741,8 @@ void CVnodePayments::Sync(CNode* pnode)
     for (int h = pCurrentBlockIndex->nHeight; h < pCurrentBlockIndex->nHeight + 20; h++) {
         if (mapVnodeBlocks.count(h)) {
             BOOST_FOREACH (CVnodePayee& payee, mapVnodeBlocks[h].vecPayees) {
-                std::vector<uint256> vecVoteHashes = payee.GetVoteHashes();
-                BOOST_FOREACH (uint256& hash, vecVoteHashes) {
+                const std::vector<uint256>& vecVoteHashes = payee.GetVoteHashes();
+                BOOST_FOREACH (const uint256& hash, vecVoteHashes) {
                     if (!HasVerifiedPaymentVote(hash))
                         continue;
                     pnode->PushInventory(CInv(MSG_VNODE_PAYMENT_VOTE, hash));

--- a/src/vnode-payments.h
+++ b/src/vnode-payments.h
@@ -68,8 +68,8 @@ public:
     CScript GetPayee() { return scriptPubKey; }
 
     void AddVoteHash(uint256 hashIn) { vecVoteHashes.push_back(hashIn); }
-    std::vector<uint256> GetVoteHashes() { return vecVoteHashes; }
-    int GetVoteCount() { return vecVoteHashes.size(); }
+    const std::vector<uint256>& GetVoteHashes() const { return vecVoteHashes; }
+    int GetVoteCount() const { return vecVoteHashes.size(); }
     std::string ToString() const;
 };
 


### PR DESCRIPTION
💡 What: Modified `GetVoteHashes` to return a `const std::vector<uint256>&` instead of a copy, avoiding unnecessary heap allocations and iterating via `const uint256&` to avoid copying vector elements in loops.

🎯 Why: In a high-throughput network scenario, repeatedly requesting properties of nodes via RPCs and internal data syncing algorithms results in constant unneeded copying of vector items and heap thrashing, which drags down performance. 

📊 Impact: Reduces heap allocation frequency when executing `ProcessGetData` and syncing Vnode Payments, as `vVnodeBlocks` queries fetch vote hashes continuously.

🔬 Measurement: Compile binary and run node synchronization under high network traffic, or run profiling tools (like `valgrind --tool=massif`) which will report reduced allocations in `.GetVoteHashes()` methods.

---
*PR created automatically by Jules for task [326376241426903814](https://jules.google.com/task/326376241426903814) started by @DerUntote*