### PR TITLE
⚡ Bolt: Optimize map lookup and string passing in netfulfilledman

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Map Lookup and String Pass-by-Value Optimization
+**Learning:** Found an inefficiency in `CNetFulfilledRequestManager::HasFulfilledRequest` where `strRequest` was being passed by value (triggering a deep string copy) and there was a redundant map lookup: `it->second.find(strRequest)` followed by `it->second[strRequest]`.
+**Action:** Use `const std::string&` for read-only string parameters and capture the iterator from `find()` to avoid performing double lookups in `std::map`.

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -8,23 +8,27 @@
 
 CNetFulfilledRequestManager netfulfilledman;
 
-void CNetFulfilledRequestManager::AddFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::AddFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
-bool CNetFulfilledRequestManager::HasFulfilledRequest(CAddress addr, std::string strRequest)
+bool CNetFulfilledRequestManager::HasFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
 
-    return  it != mapFulfilledRequests.end() &&
-            it->second.find(strRequest) != it->second.end() &&
-            it->second[strRequest] > GetTime();
+    if (it != mapFulfilledRequests.end()) {
+        fulfilledreqmapentry_t::iterator it_entry = it->second.find(strRequest);
+        if (it_entry != it->second.end()) {
+            return it_entry->second > GetTime();
+        }
+    }
+    return false;
 }
 
-void CNetFulfilledRequestManager::RemoveFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -36,9 +36,9 @@ public:
         READWRITE(mapFulfilledRequests);
     }
 
-    void AddFulfilledRequest(CAddress addr, std::string strRequest); // expire after 1 hour by default
-    bool HasFulfilledRequest(CAddress addr, std::string strRequest);
-    void RemoveFulfilledRequest(CAddress addr, std::string strRequest);
+    void AddFulfilledRequest(const CAddress& addr, const std::string& strRequest); // expire after 1 hour by default
+    bool HasFulfilledRequest(const CAddress& addr, const std::string& strRequest);
+    void RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest);
 
     void CheckAndRemove();
     void Clear();


### PR DESCRIPTION
💡 What: Changed method parameters in `CNetFulfilledRequestManager` from pass-by-value to `const std::string&` and `const CAddress&`. Refactored `HasFulfilledRequest` to use a single iterator lookup.
🎯 Why: Passing strings by value causes unnecessary deep copies of the string data. Additionally, performing a `map.find(key)` followed by `map[key]` doubles the search time in the map unnecessarily.
📊 Impact: Expected to reduce memory allocations for incoming request checks and cut lookup time in half for network fulfilled requests.
🔬 Measurement: Verified the code behavior remains unchanged while avoiding allocations and redundant lookups. Build and tested (compilation succeeds).

---
*PR created automatically by Jules for task [15322089515768512677](https://jules.google.com/task/15322089515768512677) started by @DerUntote*