### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Pre-Auth Memory Leak in RPC Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-05-20 - Memory Leak and Buffer Overflow in GetNotQualifyReason
-**Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
-**Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
-**Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2026-06-19 - Pre-Auth Memory Leak in RPC Authentication
+**Vulnerability:** A memory leak in the RPC HTTP authentication handler where 32 bytes of heap memory were leaked for every single RPC password validation attempt (`new unsigned char[KEY_SIZE]` without `delete[]`).
+**Learning:** Seemingly small memory leaks in authentication paths can become critical pre-auth Denial of Service vectors, allowing attackers to quickly cause OOM crashes just by sending failed login attempts.
+**Prevention:** Always use safe RAII primitives like `std::vector` instead of raw `new`/`delete` when allocating buffers for cryptographic operations, even temporary ones.

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -113,11 +113,10 @@ static bool multiUserAuthorized(std::string strUserPass)
             std::string strHash = vFields[2];
 
             unsigned int KEY_SIZE = 32;
-            unsigned char *out = new unsigned char[KEY_SIZE]; 
+            std::vector<unsigned char> out(KEY_SIZE);
             
-            CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);
-            std::vector<unsigned char> hexvec(out, out+KEY_SIZE);
-            std::string strHashFromPass = HexStr(hexvec);
+            CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out.data());
+            std::string strHashFromPass = HexStr(out);
 
             if (TimingResistantEqual(strHashFromPass, strHash)) {
                 return true;


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Pre-Auth Memory Leak in RPC Handler

🚨 Severity: CRITICAL
💡 Vulnerability: A memory leak existed in the RPC HTTP authentication handler (`multiUserAuthorized`) where 32 bytes of heap memory were allocated (`new unsigned char[KEY_SIZE]`) for every RPC password validation attempt but never freed.
🎯 Impact: An unauthenticated attacker could continuously spam the RPC port with fake credentials to cause memory exhaustion and an out-of-memory (OOM) Denial of Service (DoS) crash.
🔧 Fix: Replaced the raw pointer and dynamic allocation with a `std::vector<unsigned char>`, effectively leveraging RAII to automatically manage the memory and guarantee it gets cleaned up. Utilized `out.data()` to maintain compatibility with the `Finalize()` method and streamlined the code by passing the `std::vector` directly to `HexStr()`.
✅ Verification: Compiled successfully using `make -C src libbitcoin_server_a-httprpc.o` without fatal errors.

---
*PR created automatically by Jules for task [5416571344675547076](https://jules.google.com/task/5416571344675547076) started by @DerUntote*