### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH string copy in ProcessMessage with std::find

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-20 - Unintended String Copies in Network Hot Paths
+**Learning:** Legacy constructs like `BOOST_FOREACH` with `const std::string msg` (instead of `const std::string& msg`) cause hidden heap allocations for every element iterated. In high-throughput paths like network packet processing (`ProcessMessage`), this creates significant memory overhead and CPU cycles wasted on copying string objects.
+**Action:** Always inspect loop variable declarations in performance-critical areas. Use standard library algorithms like `std::find` or ensure range-based loops use `const auto&` to prevent accidental deep copies of complex types.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7127,14 +7127,8 @@ bool static ProcessMessage(CNode *pfrom, string strCommand, CDataStream &vRecv, 
     } else {
 //        LogPrintf("Main.cpp ProcessMessage() strCommand=%s\n", strCommand);
         // Ignore unknown commands for extensibility
-        bool found = false;
         const std::vector <std::string> &allMessages = getAllNetMessageTypes();
-        BOOST_FOREACH(const std::string msg, allMessages) {
-            if (msg == strCommand) {
-                found = true;
-                break;
-            }
-        }
+        bool found = std::find(allMessages.begin(), allMessages.end(), strCommand) != allMessages.end();
 
         if (found) {
             //probably one the extensions


### PR DESCRIPTION
💡 What: Replaced a `BOOST_FOREACH` loop that copied strings by value with `std::find` in `src/main.cpp`'s `ProcessMessage`.

🎯 Why: `ProcessMessage` is on the critical hot path for network communication. The legacy `BOOST_FOREACH` construct used `const std::string msg` (passing by value), which forced a heap allocation and deep copy of every possible message type string for *every* incoming message checking its validness.

📊 Impact: Eliminates O(N) string copies per incoming network message, reducing CPU overhead and memory allocations on the main message processing thread.

🔬 Measurement: Verified compilation locally. Ensures O(N) heap allocations are skipped in the hot network receiving path.

---
*PR created automatically by Jules for task [11543771975889469584](https://jules.google.com/task/11543771975889469584) started by @DerUntote*