### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH with std::find in ProcessMessage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Unnecessary String Copies in Network Loop
+**Learning:** Legacy `BOOST_FOREACH` loops that do not use references (e.g., `BOOST_FOREACH(const std::string msg, allMessages)`) cause hidden deep copies of complex types on every iteration. In a high-throughput path like `ProcessMessage`, this results in excessive heap allocations per packet.
+**Action:** Always inspect loop iteration variables for missing `&` when iterating over collections of complex types. Prefer standard library algorithms like `std::find` which cleanly avoid this issue by operating on iterators.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7127,14 +7127,11 @@ bool static ProcessMessage(CNode *pfrom, string strCommand, CDataStream &vRecv, 
     } else {
 //        LogPrintf("Main.cpp ProcessMessage() strCommand=%s\n", strCommand);
         // Ignore unknown commands for extensibility
-        bool found = false;
         const std::vector <std::string> &allMessages = getAllNetMessageTypes();
-        BOOST_FOREACH(const std::string msg, allMessages) {
-            if (msg == strCommand) {
-                found = true;
-                break;
-            }
-        }
+        // ⚡ Bolt: Replace BOOST_FOREACH loop that copied std::string by value with std::find.
+        // Impact: Eliminates ~20+ hidden heap allocations (std::string copy constructor)
+        // per unrecognized network packet, reducing latency and memory pressure on the net thread.
+        bool found = std::find(allMessages.begin(), allMessages.end(), strCommand) != allMessages.end();
 
         if (found) {
             //probably one the extensions


### PR DESCRIPTION
Avoids allocating and copying std::string inside BOOST_FOREACH loop for every unrecognized message in ProcessMessage. Uses std::find over allMessages vector, saving heap allocations and improving network processing throughput for custom protocol messages.

---
*PR created automatically by Jules for task [498222884834454870](https://jules.google.com/task/498222884834454870) started by @DerUntote*