### PR TITLE
⚡ Bolt: Optimize wallet loops to eliminate deep copies

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Eliminating BOOST_FOREACH Map Value Copies
+**Learning:** `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` iterates by value, causing hidden, expensive deep copies of the pair (including its values, like the heavy `CWalletTx` object) on every loop iteration.
+**Action:** Always replace legacy `BOOST_FOREACH` macros that iterate over maps with modern C++11 range-based `for` loops (e.g., `for (auto& item : map)`) to utilize references and completely eliminate unnecessary heap allocations and deep copies.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,7 +4315,8 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        // Optimize: Use reference instead of passing by value to avoid copying CWalletTx for each element
+        for (auto& walletEntry : mapWallet)
         {
             CWalletTx *pcoin = &walletEntry.second;
 
@@ -4353,7 +4354,8 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    // Optimize: Use reference instead of passing by value to avoid copying CWalletTx for each element
+    for (auto& walletEntry : mapWallet)
     {
         CWalletTx *pcoin = &walletEntry.second;
 


### PR DESCRIPTION
⚡ Bolt: Optimize wallet loops to eliminate deep copies

* 💡 What: Replaced `BOOST_FOREACH` iterations with C++11 range-based `for (auto& ...)` loops in `CWallet::GetAddressBalances` and `CWallet::GetAddressGroupings`.
* 🎯 Why: `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` passes `walletEntry` by value. This causes a heavy deep copy of `CWalletTx` (including all its inputs and outputs vectors) for *every* element in `mapWallet`, leading to an O(N) performance bottleneck due to excessive heap allocations.
* 📊 Impact: Eliminates N deep copies of `CWalletTx` objects, drastically reducing memory churn and improving execution speed for RPC endpoints fetching address balances/groupings.
* 🔬 Measurement: Verify by executing wallet-heavy RPC commands (like `getaddressesbyaccount` or `listaddressgroupings`) on a heavily populated wallet; observe lower memory spikes and CPU usage.

---
*PR created automatically by Jules for task [5903799066848748801](https://jules.google.com/task/5903799066848748801) started by @DerUntote*