### PR TITLE
⚡ Bolt: Eliminate O(N) deep copy overhead in CWallet loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-12-04 - Legacy BOOST_FOREACH Deep Copying Overhead
+**Learning:** Found a critical codebase-specific performance anti-pattern where legacy macro `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` silently performs O(N) deep copying of map elements, causing massive unintended memory allocations and GC overhead when iterating over large structs like `CWalletTx` in `mapWallet`.
+**Action:** Always refactor `BOOST_FOREACH` iterations over maps/collections containing large objects into modern C++ range-based `for (const auto& item : collection)` loops to use zero-cost const references instead of deep copies.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,11 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        // Bolt ⚡: Replace BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) with a range-based for loop with const reference
+        // to eliminate O(N) deep copying of CWalletTx elements and prevent massive memory allocations.
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4355,11 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    // Bolt ⚡: Eliminate deep copying of CWalletTx by iterating over mapWallet with a const reference
+    // instead of creating full copies per entry via BOOST_FOREACH value bindings.
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;


### PR DESCRIPTION
💡 What: Replaced legacy `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` loops in `CWallet::GetAddressBalances()` and `CWallet::GetAddressGroupings()` with modern C++ range-based for loops (`for (const auto& walletEntry : mapWallet)`).

🎯 Why: The legacy macro passed the `PAIRTYPE` by value. `CWalletTx` is a complex, large struct containing vectors and other nested data. This silent O(N) deep copying for every entry in the user's wallet map caused massive memory allocation overhead and performance drops when performing routine wallet balance or grouping checks.

📊 Impact: Reduces memory allocations during wallet iteration to near zero. Time complexity for looping stays O(N) but the constant factor overhead drops drastically, resulting in much faster wallet scans, particularly for wallets with thousands of transactions.

🔬 Measurement: Verify by compiling `make -C src wallet/libbitcoin_wallet_a-wallet.o` or profiling wallet startup/RPC balance calls before and after the change to observe reduced heap allocations.

---
*PR created automatically by Jules for task [10403108922520405315](https://jules.google.com/task/10403108922520405315) started by @DerUntote*