### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable PRNG in proxy stream isolation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-05-20 - Memory Leak and Buffer Overflow in GetNotQualifyReason
-**Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
-**Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
-**Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-24 - Cryptographically Insecure PRNG in SOCKS Stream Isolation
+**Vulnerability:** SOCKS proxy stream isolation was compromised by using `insecure_rand()` (a weak, predictable random number generator) for creating randomized connection credentials.
+**Learning:** Legacy developers may use non-cryptographic PRNG functions out of habit when implementing isolation mechanisms. If isolation credentials are predictable, an attacker might link purportedly isolated streams, defeating privacy networks (like Tor).
+**Prevention:** Always use `GetRandHash()` or `GetRand()` when generating anything related to connection credentials, routing isolation, or session keys, reserving `insecure_rand()` solely for non-critical scheduling or trivial randomized backoffs.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The SOCKS5 proxy connection code (`ConnectThroughProxy` in `src/netbase.cpp`) was using `insecure_rand()`—a very weak, predictable random number generator—to generate "random" usernames and passwords. When routing traffic through an anonymity network like Tor, randomized SOCKS5 credentials are used to enforce stream isolation (ensuring different connections do not share the same circuit and leak identity/correlation data).
🎯 Impact: If these credentials are mathematically predictable, an attacker running a malicious Tor exit node could potentially bypass this isolation and link separate node streams back to the same source, severely compromising privacy and security.
🔧 Fix: Replaced `insecure_rand()` with `GetRandHash().ToString()` for both the username and password generation, ensuring cryptographically secure, unpredictable stream isolation.
✅ Verification: Ran partial tests explicitly verifying compilation of `netbase.cpp` (`make -C src libbitcoin_common_a-netbase.o`) using `GetRandHash()`. Full test suite was run (`make check`) but legitimately failed due to pre-existing `<deque>` Boost compatibility issues on gcc 13. Included a critical learning note in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6147414531266782324](https://jules.google.com/task/6147414531266782324) started by @DerUntote*