### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH with range-based for loops to avoid deep copies

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Avoid `BOOST_FOREACH` with `PAIRTYPE`
+**Learning:** `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` silently makes deep copies of map elements on every iteration, leading to significant memory allocations and performance degradation, particularly when iterating over large collections like `mapWallet`.
+**Action:** Always replace legacy `BOOST_FOREACH(PAIRTYPE...` macro uses with modern C++11 range-based for loops (e.g., `for (const auto& item : map)`) to pass by reference and avoid hidden copies.

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2193,7 +2193,7 @@ int CDarksendPool::GetDenominations(const std::vector <CTxOut> &vecTxOut, bool f
     BOOST_FOREACH(CTxOut
     txout, vecTxOut) {
         bool found = false;
-        BOOST_FOREACH(PAIRTYPE(CAmount, int) &s, vecDenomUsed)
+        for (auto& s : vecDenomUsed)
         {
             if (txout.nValue == s.first) {
                 s.second = 1;
@@ -2206,7 +2206,7 @@ int CDarksendPool::GetDenominations(const std::vector <CTxOut> &vecTxOut, bool f
     int nDenom = 0;
     int c = 0;
     // if the denomination is used, shift the bit on
-    BOOST_FOREACH(PAIRTYPE(CAmount, int) &s, vecDenomUsed)
+    for (auto& s : vecDenomUsed)
     {
         int bit = (fSingleRandomDenom ? GetRandInt(2) : 1) & s.second;
         nDenom |= bit << c++;

--- a/src/rpc/rpcvnode.cpp
+++ b/src/rpc/rpcvnode.cpp
@@ -481,7 +481,7 @@ UniValue vnodelist(const UniValue &params, bool fHelp) {
     UniValue obj(UniValue::VOBJ);
     if (strMode == "rank") {
         std::vector <std::pair<int, CVnode>> vVnodeRanks = mnodeman.GetVnodeRanks();
-        BOOST_FOREACH(PAIRTYPE(int, CVnode) & s, vVnodeRanks)
+        for (auto& s : vVnodeRanks)
         {
             std::string strOutpoint = s.second.vin.prevout.ToStringShort();
             if (strFilter != "" && strOutpoint.find(strFilter) == std::string::npos) continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -740,7 +740,7 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
 void CWallet::MarkDirty() {
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)&item, mapWallet)
+        for (auto& item : mapWallet)
         item.second.MarkDirty();
     }
 }
@@ -1387,7 +1387,7 @@ void CWallet::ReacceptWalletTransactions() {
     std::map < int64_t, CWalletTx * > mapSorted;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
-    BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)&item, mapWallet)
+    for (auto& item : mapWallet)
     {
         const uint256 &wtxid = item.first;
         CWalletTx &wtx = item.second;
@@ -1404,7 +1404,7 @@ void CWallet::ReacceptWalletTransactions() {
     }
 
     // Try to add wallet transactions to memory pool
-    BOOST_FOREACH(PAIRTYPE(const int64_t, CWalletTx *)&item, mapSorted)
+    for (auto& item : mapSorted)
     {
         CWalletTx &wtx = *(item.second);
 
@@ -1630,7 +1630,7 @@ std::vector <uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime) {
     LOCK(cs_wallet);
     // Sort them in chronological order
     multimap < unsigned int, CWalletTx * > mapSorted;
-    BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)&item, mapWallet)
+    for (auto& item : mapWallet)
     {
         CWalletTx &wtx = item.second;
         // Don't rebroadcast if newer than nTime:
@@ -1638,7 +1638,7 @@ std::vector <uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime) {
             continue;
         mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
     }
-    BOOST_FOREACH(PAIRTYPE(const unsigned int, CWalletTx *)&item, mapSorted)
+    for (auto& item : mapSorted)
     {
         CWalletTx &wtx = *item.second;
         if (wtx.RelayWalletTransaction())
@@ -2730,7 +2730,7 @@ bool CWallet::SelectCoinsGrouppedByAddresses(std::vector <CompactTallyItem> &vec
 
     // construct resulting vector
     vecTallyRet.clear();
-    BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, CompactTallyItem)&item, mapTally) {
+    for (const auto& item : mapTally) {
         if (fAnonymizable && item.second.nAmount < vecPrivateSendDenominations.back()) continue;
         vecTallyRet.push_back(item.second);
     }
@@ -2871,7 +2871,7 @@ bool CWallet::CreateTransaction(const vector <CRecipient> &vecSend, CWalletTx &w
                     return false;
                 }
 
-                BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
+                for (const auto& pcoin : setCoins)
                 {
                     CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
                     //The coin age after the next block (depth+1) is used instead of the current,
@@ -2972,13 +2972,13 @@ bool CWallet::CreateTransaction(const vector <CRecipient> &vecSend, CWalletTx &w
                 //
                 // Note how the sequence number is set to max()-1 so that the
                 // nLockTime set above actually works.
-                BOOST_FOREACH(const PAIRTYPE(const CWalletTx *, unsigned int) &coin, setCoins)
+                for (const auto& coin : setCoins)
                     txNew.vin.push_back(CTxIn(coin.first->GetHash(), coin.second, CScript(), std::numeric_limits < unsigned int > ::max() - 1));
 
                 // Sign
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
-                BOOST_FOREACH(const PAIRTYPE(const CWalletTx *, unsigned int) &coin, setCoins)
+                for (const auto& coin : setCoins)
                 {
                     bool signSuccess;
                     const CScript &scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
@@ -3364,7 +3364,7 @@ bool CWallet::CreateZerocoinMintTransaction(const vector <CRecipient> &vecSend, 
                     }
                     return false;
                 }
-                BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
+                for (const auto& pcoin : setCoins)
                 {
                     CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
                     //The coin age after the next block (depth+1) is used instead of the current,
@@ -3472,14 +3472,14 @@ bool CWallet::CreateZerocoinMintTransaction(const vector <CRecipient> &vecSend, 
                 //
                 // Note how the sequence number is set to max()-1 so that the
                 // nLockTime set above actually works.
-                BOOST_FOREACH(const PAIRTYPE(const CWalletTx *, unsigned int) &coin, setCoins)
+                for (const auto& coin : setCoins)
                     txNew.vin.push_back(CTxIn(coin.first->GetHash(), coin.second, CScript(),
                                           std::numeric_limits < unsigned int > ::max() - 1));
 
                 // Sign
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
-                BOOST_FOREACH(const PAIRTYPE(const CWalletTx *, unsigned int) &coin, setCoins)
+                for (const auto& coin : setCoins)
                 {
                     bool signSuccess;
                     const CScript &scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
@@ -4152,7 +4152,7 @@ bool CWallet::DelAddressBook(const CTxDestination &address) {
         if (fFileBacked) {
             // Delete destdata tuples associated with address
             std::string strAddress = CBitcoinAddress(address).ToString();
-            BOOST_FOREACH(const PAIRTYPE(string, string) &item, mapAddressBook[address].destdata)
+            for (const auto& item : mapAddressBook[address].destdata)
             {
                 CWalletDB(strWalletFile).EraseDestData(strAddress, item.first);
             }
@@ -4315,9 +4315,9 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4353,9 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;
@@ -4468,7 +4468,7 @@ CAmount CWallet::GetAccountBalance(CWalletDB &walletdb, const std::string &strAc
 std::set <CTxDestination> CWallet::GetAccountAddresses(const std::string &strAccount) const {
     LOCK(cs_wallet);
     set <CTxDestination> result;
-    BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)&item, mapAddressBook)
+    for (const auto& item : mapAddressBook)
     {
         const CTxDestination &address = item.first;
         const string &strName = item.second.name;


### PR DESCRIPTION
💡 What: Replaced legacy `BOOST_FOREACH(PAIRTYPE...` constructs with C++11 range-based for loops.
🎯 Why: `BOOST_FOREACH` with `PAIRTYPE` silently makes deep copies of map elements on every iteration, causing unnecessary memory allocation and performance degradation.
📊 Impact: Eliminates redundant heap allocations during loop iterations over large map containers, reducing CPU cycles and memory usage.
🔬 Measurement: Verify compilation and tests pass successfully; no functional changes, strictly performance improvement.

---
*PR created automatically by Jules for task [811799316046123756](https://jules.google.com/task/811799316046123756) started by @DerUntote*