### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH value copy with const reference loop in wallet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-28 - Avoid deep copies in BOOST_FOREACH
+**Learning:** Found legacy `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` loops that unintentionally perform deep copies by passing `PAIRTYPE(uint256, CWalletTx)` by value instead of reference `PAIRTYPE(const uint256, CWalletTx)&` or using modern C++11 range-based for loops `for (const auto& walletEntry : mapWallet)`.
+**Action:** Always replace value-type `BOOST_FOREACH` over maps with range-based for loops with `const auto&` to prevent hidden copies of large types like `CWalletTx`.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,9 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4353,9 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;


### PR DESCRIPTION
💡 What: Replaced `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` with `for (const auto& walletEntry : mapWallet)` in `CWallet::GetAddressBalances()` and `CWallet::GetAddressGroupings()`.
🎯 Why: The legacy `BOOST_FOREACH` was unintentionally performing a deep copy of the `CWalletTx` object for every entry in `mapWallet`. Using a C++11 range-based for loop with a const reference prevents these unnecessary and expensive heap allocations.
📊 Impact: Reduces memory overhead and improves performance when querying address balances and groupings, especially for wallets with a large number of transactions.
🔬 Measurement: Verify that `GetAddressBalances` and `GetAddressGroupings` are executed faster and with fewer allocations during wallet operations.

---
*PR created automatically by Jules for task [13097707417952301584](https://jules.google.com/task/13097707417952301584) started by @DerUntote*