### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure PRNG for proxy credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-24 - Secure PRNG for Proxy Credentials
+**Vulnerability:** SOCKS5 proxy credentials were generated using `insecure_rand()`.
+**Learning:** `insecure_rand()` is not cryptographically secure and produces predictable outputs. Using it for proxy credentials compromises stream isolation and privacy by allowing network traffic to be tracked.
+**Prevention:** Always use a CSPRNG such as `GetRandHash()` or `GetRand()` when generating sensitive data like network credentials, tokens, or encryption keys.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Use of insecure PRNG `insecure_rand()` for generating proxy credentials (username/password), which compromises network proxy isolation security.
🎯 Impact: Predictable credentials could allow attackers to bypass stream isolation, de-anonymizing or tracking network connections.
🔧 Fix: Replaced `insecure_rand()` with the secure, cryptographically strong `GetRandHash().ToString()`.
✅ Verification: Verified compilation of `src/netbase.cpp` and ensured all tests pass via `make check`.

---
*PR created automatically by Jules for task [4832324240633370063](https://jules.google.com/task/4832324240633370063) started by @DerUntote*