### PR TITLE
🛡️ Sentinel: [HIGH] Fix weak PRNG in proxy credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+
+## 2024-05-21 - Weak PRNG for Proxy Credentials
+**Vulnerability:** The proxy connection code used `insecure_rand()` (a weak PRNG) to generate SOCKS5 proxy credentials for circuit isolation.
+**Learning:** `insecure_rand()` should never be used for security-critical operations, such as network isolation, as predictable credentials can lead to identity correlation or isolation bypass.
+**Prevention:** Always use a CSPRNG, such as `GetRandHash()` or `GetRand()`, for generating credentials or any security-sensitive random values.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,10 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        // Use a CSPRNG for generating SOCKS5 credentials to ensure secure circuit isolation.
+        // insecure_rand() must not be used for this as it's predictable.
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The SOCKS5 proxy credential generation used a weak pseudo-random number generator (`insecure_rand()`).
* 🎯 Impact: Predictable credentials could allow attackers to correlate proxy connections, bypass circuit isolation, or deanonymize users.
* 🔧 Fix: Replaced `insecure_rand()` with `GetRandHash().ToString()`, a cryptographically secure pseudo-random number generator.
* ✅ Verification: Verified compilation of `src/netbase.cpp` and ran the overall test suite (`make check`).

---
*PR created automatically by Jules for task [10618827267325507000](https://jules.google.com/task/10618827267325507000) started by @DerUntote*