### PR TITLE
⚡ Bolt: Optimize wallet loops by removing deep copies

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Avoid deep copies in map iteration
+**Learning:** Legacy Boost loops like `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` perform silent deep copies.
+**Action:** Replace `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` with `for (auto& item : map)` or `for (const auto& item : map)` to prevent redundant allocations and speed up iteration.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,10 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        // Optimize: Use const auto& to prevent silent deep copying of map elements
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4354,10 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    // Optimize: Use const auto& to prevent silent deep copying of map elements
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;


### PR DESCRIPTION
💡 What: Replaced `BOOST_FOREACH` with range-based for loops that use references.
🎯 Why: `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` performs a silent deep copy of every transaction in the wallet when getting balances or groupings, causing unnecessary allocations and slowing down wallet operations.
📊 Impact: Significantly reduces memory allocations and heap copying during wallet state traversal, making `GetAddressBalances` and `GetAddressGroupings` faster.
🔬 Measurement: Observe reduced CPU/memory overhead during wallet iterations in `GetAddressBalances` and `GetAddressGroupings`.

---
*PR created automatically by Jules for task [10875282726991874290](https://jules.google.com/task/10875282726991874290) started by @DerUntote*