### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak SOCKS5 proxy credentials generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-18 - Insecure Randomness in SOCKS5 Proxy Credentials
+**Vulnerability:** SOCKS5 proxy credentials generated using `insecure_rand()`, which is predictable and could lead to credential prediction or stream deanonymization.
+**Learning:** Legacy PRNGs (`insecure_rand`) are unsuitable for generating any network credentials, even for stream isolation.
+**Prevention:** Use a cryptographically secure PRNG (like `GetRandHash()`) for generating unpredictable tokens and credentials.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString().substr(0, 16);
+        random_auth.password = GetRandHash().ToString().substr(0, 16);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Proxy credentials for SOCKS5 stream isolation were being generated using a weak pseudo-random number generator (`insecure_rand()`). This could allow attackers to predict credentials and bypass stream isolation or link connections.
🎯 **Impact:** If exploited, it could result in deanonymizing proxy traffic streams due to predictable credential re-use.
🔧 **Fix:** Replaced `insecure_rand()` with `GetRandHash().ToString().substr(0, 16)` to generate cryptographically secure, unpredictable stream isolation credentials.
✅ **Verification:** Verified via `make check` and isolated compilation.

---
*PR created automatically by Jules for task [18047137422075754045](https://jules.google.com/task/18047137422075754045) started by @DerUntote*