### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak RNG for stream isolation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-15 - Fix weak RNG for Tor stream isolation credentials
+**Vulnerability:** The code used `insecure_rand()` to generate usernames and passwords for Tor SOCKS5 proxy authentication, which is intended for stream isolation.
+**Learning:** `insecure_rand()` is a weak PRNG and should not be used for security-critical or privacy-critical purposes. Weak credentials could allow an attacker to predict the stream and deanonymize users.
+**Prevention:** Always use a cryptographically secure pseudo-random number generator (CSPRNG) like `GetRandHash()` or `GetRand()` for security and privacy credentials.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ConnectThroughProxy` function used the weak, predictable `insecure_rand()` PRNG to generate username and password credentials for Tor SOCKS5 proxy authentication.
🎯 Impact: This weak randomness undermines Tor stream isolation, potentially allowing an attacker to predict the stream credentials, correlate transactions, and deanonymize users.
🔧 Fix: Replaced `strprintf("%i", insecure_rand())` with `GetRandHash().ToString()` to generate strong, unpredictable credentials using the application's cryptographically secure PRNG (CSPRNG).
✅ Verification: Built `src/netbase.cpp` using `make -C src libbitcoin_common_a-netbase.o` and ran the full test suite (`make check`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12554400266838122516](https://jules.google.com/task/12554400266838122516) started by @DerUntote*