### PR TITLE
🛡️ Sentinel: [HIGH] Replace insecure_rand() with CSPRNG for Proxy Credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-24 - Insecure Randomness in Proxy Authentication
+**Vulnerability:** Used non-cryptographic `insecure_rand()` to generate random proxy credentials (SOCKS5 username/password) in `src/netbase.cpp` for stream isolation.
+**Learning:** Using weak PRNGs for network credentials degrades stream isolation security, as an attacker might predict the credentials and correlate traffic.
+**Prevention:** Always use cryptographically secure random number generators (CSPRNGs) like `GetRandHash()` when generating any network credentials, even when the proxy server ignores them (as Tor does), since the entropy guarantees isolation.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Used `insecure_rand()` to generate proxy credentials (username/password) in `ConnectThroughProxy`.
- 🎯 Impact: Weak entropy could allow attackers to predict credentials and bypass Tor's stream isolation, correlating user traffic.
- 🔧 Fix: Replaced `insecure_rand()` with `GetRandHash().ToString()` to ensure cryptographic randomness.
- ✅ Verification: Successfully built `libbitcoin_common_a-netbase.o` using `make`.

---
*PR created automatically by Jules for task [6958809429343365908](https://jules.google.com/task/6958809429343365908) started by @DerUntote*