### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix weak RNG in proxy credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2026-07-05 - Fix Weak RNG in Proxy Credentials
+**Vulnerability:** The application used `insecure_rand()` (a weak, non-cryptographic PRNG) to generate proxy authentication credentials for Tor stream isolation.
+**Learning:** `insecure_rand()` is predictable and should not be used for security-critical contexts like network credentials or stream isolation.
+**Prevention:** Always use a CSPRNG like `GetRandHash()` or `GetRand()` for generating credentials, keys, or nonces.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used weak PRNG (`insecure_rand()`) for Tor stream isolation credentials.
🎯 Impact: Predictable credentials could allow attackers to correlate Tor streams, compromising user anonymity.
🔧 Fix: Replaced `insecure_rand()` with the cryptographically secure `GetRandHash()`.
✅ Verification: Verified compilation and ran the test suite to ensure the fix does not break proxy connections.

---
*PR created automatically by Jules for task [14270832694628258666](https://jules.google.com/task/14270832694628258666) started by @DerUntote*