### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH with range-based loops to eliminate deep copies in CWallet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - [Optimize CWallet::GetAddressBalances]
+**Learning:** Found an inefficient `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` loop that copies map entries by value, leading to unnecessary copying.
+**Action:** Always replace value-based map iterations with const reference loops (`const auto&`) or C++11 range-based loops to prevent redundant allocations and deep copies.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,9 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4353,9 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;


### PR DESCRIPTION
💡 What: Replaced value-based `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)` loops with const reference loops (`for (const auto& walletEntry : mapWallet)`) in CWallet::GetAddressBalances and CWallet::GetAddressGroupings.
🎯 Why: `BOOST_FOREACH` using `PAIRTYPE` causes deep copies of map entries on each iteration, which leads to redundant heap allocations and negatively impacts multithreaded performance.
📊 Impact: Reduces heap allocation and deep copying over entire map arrays.
🔬 Measurement: Verify expected behavior and compilation locally.

---
*PR created automatically by Jules for task [15093742037757491328](https://jules.google.com/task/15093742037757491328) started by @DerUntote*