### PR TITLE
⚡ Bolt: Prevent deep copies of CWalletTx in wallet queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Unintended Value Copies in Legacy BOOST_FOREACH
+**Learning:** Legacy `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` silently makes deep copies of complex map elements if the reference operator `&` is omitted. In multithreaded wallet queries, copying large objects like `CWalletTx` causes significant heap allocation overhead.
+**Action:** Proactively replace value-copying `BOOST_FOREACH` loops with C++11 range-based `for (const auto& item : map)` loops to eliminate redundant allocations, updating inner pointers to `const T*` to maintain const-correctness.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,9 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,14 +4353,14 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;
             // group all input addresses with each other
-            BOOST_FOREACH(CTxIn txin, pcoin->vin)
+            for (const auto& txin : pcoin->vin)
             {
                 CTxDestination address;
                 if (!IsMine(txin)) /* If this input isn't mine, ignore it */


### PR DESCRIPTION
💡 What: Replaced value-copying BOOST_FOREACH loops with const reference C++11 range-based loops.
🎯 Why: Reduces memory allocations and CPU overhead during balance and grouping queries.
📊 Impact: Eliminates expensive deep copies of CWalletTx and CTxIn objects, speeding up wallet operations.
🔬 Measurement: Verified compilation and ran the test suite (`make check`).

---
*PR created automatically by Jules for task [17804579239977877583](https://jules.google.com/task/17804579239977877583) started by @DerUntote*