### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak randomness in proxy authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,9 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+
+## 2024-05-18 - Fix Weak Randomness in Proxy Auth
+
+**Vulnerability:** Weak PRNG `insecure_rand()` used for SOCKS5 proxy credentials, leading to predictable credentials and potential loss of stream isolation for network proxy connections (e.g. Tor).
+**Learning:** `insecure_rand()` is deterministic and inadequate for generating credentials. Stream isolation relies on distinct credentials.
+**Prevention:** Always use cryptographically secure randomness, like `GetRandHash()`, when generating proxy or authentication credentials.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Weak PRNG `insecure_rand()` was used for generating SOCKS5 proxy credentials.
🎯 Impact: Predictable credentials could lead to a loss of stream isolation for network proxy connections (e.g., Tor), potentially exposing user activity and defeating privacy protections.
🔧 Fix: Replaced `insecure_rand()` with the cryptographically secure `GetRandHash().ToString()`.
✅ Verification: Verified compilation of `src/netbase.cpp` and ensured no regressions were introduced.

---
*PR created automatically by Jules for task [8760623856921223574](https://jules.google.com/task/8760623856921223574) started by @DerUntote*