### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure proxy credential generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A memory leak was present due to `CVnodeMan::GetNotQualifyReason` dynamically allocating character buffers (`new char[256]`) without proper freeing in the call site in `src/rpc/rpcvnode.cpp`. Additionally, using `sprintf` and hardcoded buffer sizes (`256`) risks a buffer overflow if the formatted string length exceeds the buffer length. This could potentially cause a Denial of Service.
 **Learning:** Returning `char*` that transfers ownership requires explicit `delete[]` at all call sites, which is error-prone. Legacy C-style formatting (`sprintf`) on fixed-size buffers introduces buffer overflow risks.
 **Prevention:** Use memory-safe, modern C++ constructs: prefer `std::string` as the return type over `char*` arrays and use safe format wrappers like `strprintf` to mitigate both memory leaks and buffer overflows.
+## 2024-05-24 - Insecure random network proxy credential generation
+**Vulnerability:** SOCKS5 proxy credentials were generated using `insecure_rand()` via `strprintf("%i", insecure_rand())` in `src/netbase.cpp`.
+**Learning:** Using predictable, non-cryptographic random numbers (`insecure_rand()`) for network authentication compromises stream isolation and proxy security.
+**Prevention:** Always use `GetRandHash()` or `GetRand()` for generating security-critical credentials and stream isolation identifiers.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -537,8 +537,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        random_auth.username = GetRandHash().ToString();
+        random_auth.password = GetRandHash().ToString();
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SOCKS5 proxy credentials were generated using `insecure_rand()`, allowing predictable network stream identification.
🎯 Impact: Predictable credentials could allow attackers or malicious exit nodes to correlate network streams, bypassing proxy isolation mechanisms.
🔧 Fix: Replaced `insecure_rand()` with the cryptographically secure `GetRandHash().ToString()` for generating random proxy credentials in `src/netbase.cpp`.
✅ Verification: Compiled `netbase.o` and ensured the proxy credential generation logic correctly uses the CSPRNG.

---
*PR created automatically by Jules for task [3719959197051544757](https://jules.google.com/task/3719959197051544757) started by @DerUntote*