### PR TITLE
⚡ Bolt: Replace BOOST_FOREACH with reference iteration in mapWallet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid Deep Copies in BOOST_FOREACH Map Iteration
+**Learning:** BOOST_FOREACH with PAIRTYPE makes deep value copies of map elements. In multithreaded code where a lock is held, iterating by reference (`const auto&`) prevents unnecessary heap allocations and speeds up iteration significantly.
+**Action:** Replace `BOOST_FOREACH(PAIRTYPE(K, V) item, map)` with `for (const auto& item : map)` and update inner pointer declarations to `const` when iterating over large collections of complex objects like `CWalletTx`.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,9 +4315,10 @@ std::map <CTxDestination, CAmount> CWallet::GetAddressBalances() {
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        // PERFORMANCE: Use const reference to avoid deep copy of CWalletTx
+        for (const auto& walletEntry : mapWallet)
         {
-            CWalletTx *pcoin = &walletEntry.second;
+            const CWalletTx *pcoin = &walletEntry.second;
 
             if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
                 continue;
@@ -4353,9 +4354,10 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     set <set<CTxDestination>> groupings;
     set <CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    // PERFORMANCE: Use const reference to avoid deep copy of CWalletTx
+    for (const auto& walletEntry : mapWallet)
     {
-        CWalletTx *pcoin = &walletEntry.second;
+        const CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {
             bool any_mine = false;


### PR DESCRIPTION
💡 What: Replaced value-copying `BOOST_FOREACH` iterations over `mapWallet` with C++11 `for (const auto& ...)` reference iterations.
🎯 Why: `BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx)...)` silently made deep copies of `CWalletTx` (which contains vectors and complex structures) on each loop iteration, causing significant overhead in `GetAddressBalances()` and `GetAddressGroupings()`.
📊 Impact: Significantly reduces memory allocations and heap pressure during wallet address/balance queries, reducing iteration time for large wallets.
🔬 Measurement: Observe lower CPU usage and faster RPC response times for `listaddressgroupings` and balance querying commands in large wallets.

---
*PR created automatically by Jules for task [17341113581829884861](https://jules.google.com/task/17341113581829884861) started by @DerUntote*